### PR TITLE
feat(test-lerna-semantic-release-p2): add additional 'p' to keepup wi…

### DIFF
--- a/packages/test-lerna-semantic-release-p2/index.js
+++ b/packages/test-lerna-semantic-release-p2/index.js
@@ -1,3 +1,3 @@
-const magicP2String = 'p2';
+const magicP2String = 'pp2';
 
 exports.default = magicP2String;


### PR DESCRIPTION
…th p1 package

affects: @elmariofredo/test-lerna-semantic-release-p2

BREAKING CHANGE:
now we are using 'pp' instead of 'p'